### PR TITLE
Upgrade Teasynth and canvas for Deno 2 compatibility

### DIFF
--- a/Scripts/deps.js
+++ b/Scripts/deps.js
@@ -1,8 +1,8 @@
 // Switch between local copy and published version of Teasynth here:
-export { renderMacro } from 'https://raw.githubusercontent.com/pac-dev/Teasynth/v1.0.1/teasynth.js';
+export { renderMacro } from 'https://raw.githubusercontent.com/pac-dev/Teasynth/v1.0.2/teasynth.js';
 // export { renderMacro } from '../../Teasynth/teasynth.js';
 
-export { createCanvas } from 'https://deno.land/x/canvas@v1.4.1/mod.ts';
+export { createCanvas } from 'https://deno.land/x/canvas@v1.4.2/mod.ts';
 export { existsSync } from 'https://deno.land/std@0.217.0/fs/mod.ts';
 export * as path from 'https://deno.land/std@0.217.0/path/mod.ts';
 export { parse } from 'https://deno.land/std@0.217.0/flags/mod.ts';


### PR DESCRIPTION
Note that this won't work until the Deno 2 compatible version of Teasynth has been released with a v1.0.2 tag.